### PR TITLE
Document MacOS key substitutions

### DIFF
--- a/_data/keymap.json
+++ b/_data/keymap.json
@@ -69,11 +69,13 @@
   },
   {
     "combination": "ctrl+tab",
-    "action": "root:switch-to-next-tab"
+    "action": "root:switch-to-next-tab",
+    "note": "ctrl+tab on macOS"
   },
   {
     "combination": "ctrl+shift+tab",
-    "action": "root:switch-to-previous-tab"
+    "action": "root:switch-to-previous-tab",
+    "note": "ctrl+shift+tab on macOS"
   },
   {
     "combination": "ctrl+pageup",
@@ -85,39 +87,48 @@
   },
   {
     "combination": "alt+1",
-    "action": "root:switch-to-tab-1"
+    "action": "root:switch-to-tab-1",
+    "note": "cmd+1 on macOS"
   },
   {
     "combination": "alt+2",
-    "action": "root:switch-to-tab-2"
+    "action": "root:switch-to-tab-2",
+    "note": "cmd+2 on macOS"
   },
   {
     "combination": "alt+3",
-    "action": "root:switch-to-tab-3"
+    "action": "root:switch-to-tab-3",
+    "note": "cmd+3 on macOS"
   },
   {
     "combination": "alt+4",
-    "action": "root:switch-to-tab-4"
+    "action": "root:switch-to-tab-4",
+    "note": "cmd+4 on macOS"
   },
   {
     "combination": "alt+5",
-    "action": "root:switch-to-tab-5"
+    "action": "root:switch-to-tab-5",
+    "note": "cmd+5 on macOS"
   },
   {
     "combination": "alt+6",
-    "action": "root:switch-to-tab-6"
+    "action": "root:switch-to-tab-6",
+    "note": "cmd+6 on macOS"
   },
   {
     "combination": "alt+7",
-    "action": "root:switch-to-tab-7"
+    "action": "root:switch-to-tab-7",
+    "note": "cmd+7 on macOS"
   },
   {
     "combination": "alt+8",
-    "action": "root:switch-to-tab-8"
+    "action": "root:switch-to-tab-8",
+    "note": "cmd+8 on macOS"
   },
   {
     "combination": "alt+9",
-    "action": "root:switch-to-tab-9"
+    "action": "root:switch-to-tab-9",
+    "note": "cmd+9 on macOS"
   },
   {
     "combination": "ctrl+f",

--- a/_includes/project/keymap.liquid
+++ b/_includes/project/keymap.liquid
@@ -14,6 +14,9 @@
 			<th>
 				<span data-localize="team_contrib">Actions</span>
 			</th>
+			<th>
+				<span data-localize="team_contrib">Notes</span>
+			</th>
 		</tr>
 	</thead>
 	<tbody>
@@ -21,6 +24,7 @@
 		<tr>
 			<td>{{ key.combination }}</td>
 			<td>{{ key.action }}</td>
+			<td>{{ key.note }}</td>
 		</tr>
 {%-endfor-%}
 	</tbody>

--- a/en/keymap.md
+++ b/en/keymap.md
@@ -1,6 +1,8 @@
 ---
 title: "Default keymap"
 ---
-*Note: When using macOS `ctrl` refers to the command key.*
+*Note: When using **macOS**, unless otherwise noted,
+`ctrl` refers to the `cmd` (command) key
+and `alt` refers to `cmd+ctrl`.*
 
 {%- include project/keymap.liquid -%}


### PR DESCRIPTION
Reflects:

- https://github.com/lite-xl/lite-xl/pull/263
- https://github.com/lite-xl/lite-xl/pull/264

Notes:

1.  I added a “Notes” column to the keymap table. Another possible option could be to add a “MacOS” column documenting all keys that deviate.
2.  Not sure what would be the appropriate `data-localize` attribute values in the table headers, just that they don't look right.
