### PR TITLE
Add MacPorts Documentation

### DIFF
--- a/en/downloads/index.md
+++ b/en/downloads/index.md
@@ -2,6 +2,23 @@
 title: "Downloads"
 ---
 
-[Lite XL Latest Release][1]
+[![Packaging status](https://repology.org/badge/vertical-allrepos/lite-xl.svg)][1]
+{: .img-align-right}
 
-[1]: https://github.com/lite-xl/lite-xl/releases/latest
+## Manual Install
+
+Binary packages are available on the [GitHub releases page][2].
+
+## MacPorts
+
+Lite XL can also be installed on macOS via [MacPorts][3]:
+
+```
+sudo port install lite-xl
+```
+
+[1]: https://repology.org/project/lite-xl/versions
+[2]: https://github.com/lite-xl/lite-xl/releases/latest
+[3]: https://ports.macports.org/port/lite-xl/
+
+


### PR DESCRIPTION
Following from https://github.com/lite-xl/lite-xl/issues/344, I noted in the Downloads section how you can install Lite XL via [MacPorts](https://ports.macports.org/port/lite-xl/).

I also added the [repology page](https://repology.org/project/lite-xl/versions) for the project.