### PR TITLE
add github release exporter

### DIFF
--- a/_tools/export-release-notes.js
+++ b/_tools/export-release-notes.js
@@ -1,0 +1,76 @@
+const { join } = require('path')
+const { writeFileSync } = require('fs')
+
+const sanitize = require('sanitize-filename')
+const c = require('centra')
+
+
+const USER_AGENT = 'ReleaseScrapperBot/1.0 (+https://github.com/lite-xl/lite-xl.github.io)'
+const REPO_NAME = 'lite-xl/lite-xl'
+const DIR = '_posts'
+
+const assetRegex = /lite-xl-([^-]+)-(x86-64|[^-]+)(-msys)?\.(.+)$/
+const osList = {
+  linux: 'Linux',
+  macos: 'MacOS',
+  win: 'Windows',
+}
+const archList = {
+  'x86': '32-bit',
+  'x86-64': '64-bit',
+}
+const formatList = {
+  '-msyszip': 'MSYS-style zip',
+  'zip': 'zip',
+  'tar.gz': 'tarball',
+  'dmg': 'Installer',
+  'exe': 'Installer',
+}
+
+
+const dateStr = date => date.getFullYear().toString()
+  + '-'
+  + (date.getMonth() + 1).toString().padStart(2, '0')
+  + '-'
+  + date.getDate().toString().padStart(2, '0')
+
+
+const json = url => c(url)
+  .header('User-Agent', USER_AGENT)
+  .send()
+  .then(r => r.json())
+
+
+const assetLink = asset => {
+  const [_, os, arch, msys, format] = asset.name.match(assetRegex)
+  return `- [${osList[os]} ${archList[arch]} ${formatList[(msys || '') + format]}](${asset.browser_download_url})`
+}
+
+
+const articleName = (name, date) => `${dateStr(new Date(date))}-${name}.md`
+
+
+const makeArticle = release => `
+---
+title: "${release.name}"
+author: "${release.author.login}"
+date: "${new Date(release.published_at).toISOString()}"
+---
+${release.body}
+
+##### Download links:
+${release.assets.filter(a => assetRegex.test(a.name)).map(assetLink).join('\n') || '- None'}
+`.trim()
+
+
+async function main() {
+  const releases = await json(`https://api.github.com/repos/${REPO_NAME}/releases`)
+  const exported = releases
+    .map(makeArticle)
+    .map((article, i)=> [ article, sanitize(articleName(releases[i].name, releases[i].published_at)) ])
+    .map(([article, name]) => writeFileSync(join(DIR, name), article))
+
+  console.log(`Exported ${exported.length} release note(s)`)
+}
+
+main()

--- a/_tools/export-release-notes.js
+++ b/_tools/export-release-notes.js
@@ -53,11 +53,13 @@ const articleName = (name, date) => `${dateStr(new Date(date))}-${name}.md`
 
 const makeArticle = release => `
 ---
-title: "${release.name}"
-author: "${release.author.login}"
+title: ${JSON.stringify(release.name)}
+author: ${JSON.stringify(release.author.login)}
 date: "${new Date(release.published_at).toISOString()}"
 ---
 ${release.body}
+
+> See: [GitHub release page](${release.html_url})
 
 ##### Download links:
 ${release.assets.filter(a => assetRegex.test(a.name)).map(assetLink).join('\n') || '- None'}

--- a/_tools/export-release-notes.js
+++ b/_tools/export-release-notes.js
@@ -37,6 +37,7 @@ const dateStr = date => date.getFullYear().toString()
 
 const json = url => c(url)
   .header('User-Agent', USER_AGENT)
+  .header('Application-Type', 'application/vnd.github.v3+json')
   .send()
   .then(r => r.json())
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"css-minify": "node node_modules/clean-css-cli/bin/cleancss --level 1 --source-map --source-map-inline-sources --output assets/css/style.min.css node_modules/bootstrap/dist/css/bootstrap.min.css assets/css/style.css",
 		"js": "node node_modules/npm-run-all/bin/run-s/index.js js-minify",
 		"js-minify": "node node_modules/uglify-js/bin/uglifyjs --compress --mangle --comments \"/^!/\" --source-map \"includeSources,url=scripts.min.js.map\" --output assets/js/scripts.min.js node_modules/jquery/dist/jquery.min.js node_modules/bootstrap/dist/js/bootstrap.min.js _assets/js/*.js",
-		"dist": "node node_modules/npm-run-all/bin/run-p/index.js css js"
+		"export-release-notes": "node _tools/export-release-notes.js",
+		"dist": "node node_modules/npm-run-all/bin/run-p/index.js css js export-release-notes"
 	},
 	"browserslist": [
 		"defaults"
@@ -29,12 +30,14 @@
 	"dependencies": {
 		"autoprefixer": "^9.7.6",
 		"bootstrap": "^4.4.1",
+		"centra": "^2.5.0",
 		"clean-css-cli": "^4.3.0",
 		"jquery": ">=3.5.0",
-		"sass": "^1.25.0",
 		"npm-run-all": "^4.1.5",
 		"popper.js": "^1.16.1",
 		"postcss-cli": "^7.1.0",
+		"sanitize-filename": "^1.6.3",
+		"sass": "^1.25.0",
 		"uglify-js": "^3.9.1"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -158,6 +158,11 @@ caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001251:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz#cb16e4e3dafe948fc4a9bb3307aea054b912019a"
   integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
 
+centra@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/centra/-/centra-2.5.0.tgz#854c30f9a3ff50da49fa69a8cb441aa25aa1e8e8"
+  integrity sha512-CnSF1HD8vOOgNbE4P2fZEhdhfAohvpcF3DSdSvEcSHDAZvr+Xfw73isT8SXJJc3VMBqSwjXhr29/ikHUgFcypg==
+
 chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -1036,6 +1041,13 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+sanitize-filename@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz#755ebd752045931977e30b2025d340d7c9090378"
+  integrity sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==
+  dependencies:
+    truncate-utf8-bytes "^1.0.0"
+
 sass@^1.25.0:
   version "1.38.2"
   resolved "https://registry.yarnpkg.com/sass/-/sass-1.38.2.tgz#970045d9966180002a8c8f3820fc114cddb42822"
@@ -1194,6 +1206,13 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+truncate-utf8-bytes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz#405923909592d56f78a5818434b0b78489ca5f2b"
+  integrity sha1-QFkjkJWS1W94pYGENLC3hInKXys=
+  dependencies:
+    utf8-byte-length "^1.0.1"
+
 uglify-js@^3.9.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.14.1.tgz#e2cb9fe34db9cb4cf7e35d1d26dfea28e09a7d06"
@@ -1213,6 +1232,11 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+utf8-byte-length@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz#f45f150c4c66eee968186505ab93fcbb8ad6bf61"
+  integrity sha1-9F8VDExm7uloGGUFq5P8u4rWv2E=
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
I know that I don't need to PR, but I want to PR this to discuss about what we should do with it.

As the name suggests this script gets all the release notes from lite-xl/lite-xl and automagically convert them into news articles.
It looks something like this:
![image](https://user-images.githubusercontent.com/20792268/132638020-b8db14fa-652d-4802-84c3-6ec632493cc1.png)

As for very old releases that doesn't include files, it is presented as such.
![image](https://user-images.githubusercontent.com/20792268/132638123-4da1090b-051c-4de2-8dda-9e41b11eec48.png)

### Inline links VS. reference links
These generated markdown has inline links. Links in Github releases are copied as-is, while links generated by the script are also inline. This is because naively writing reference links might just break something.

### Perserving news
Currently these posts aren't added to Git for versioning. They're generated during CI. The script only pulls the last 30 releases - this means news entries might just "disappear" in the future. How do we deal with this?

