### PR TITLE
Add MacPorts LuaJIT Docs

### DIFF
--- a/en/downloads.md
+++ b/en/downloads.md
@@ -30,10 +30,17 @@ Lite XL can also be installed on macOS via [MacPorts][4]:
 sudo port install lite-xl
 ```
 
+The [LuaJIT-based version][5] of Lite XL is also available:
+
+```
+sudo port install lite-xl-luajit
+```
+
 [1]: https://repology.org/project/lite-xl/versions
 [2]: https://github.com/lite-xl/lite-xl/
 [3]: https://github.com/lite-xl/lite-xl/releases/latest
 [4]: https://ports.macports.org/port/lite-xl/
+[5]: https://ports.macports.org/port/lite-xl-luajit/
 
 [Archlinux]: https://aur.archlinux.org/packages/lite-xl/
 


### PR DESCRIPTION
With the release of 2.0.3, I added the LuaJIT branch of Lite XL to MacPorts! Its project page can be found [here](https://ports.macports.org/port/lite-xl-luajit/) and it can be installed by running the following:

```sh
$ sudo port install lite-xl-luajit
```

Pre-built binaries are provided from macOS 11 arm to 10.7 from 2011.
