### PR TITLE
Updates for site.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,40 @@
 # [Lite XL][1] website
 
-This website is built using markdown, and a few line ruby script.
+This website is built with markdown and a tiny ruby script as a static site generator.
 
 ## Local Build Quick-start Guide
+
 - Install the required dependencies: `ruby`, and the `redcarpet` and `rouge` gems.
 - If you have ruby, you can install `redcarpet` and `rouge` with `gem install redcarpet rouge`.
-- Run `site.rb`. It should generate `index.html`, which can be opened directly in your browser.
+- Run `site.rb`. It should generate the website in-place. You'll need a HTTP server[₁][2][₂][3] to preview it.
+
+> If you use `python3`'s `http.server`, the links on the website may not work correctly as `http.server` requires
+> the full filename (with the `.html` file extension) while the website does not use that. `http-server` does not have
+> this limitation.
 
 ## Extra goodies
-- get [watchexec][2] for watching directories.
+
+#### Auto updates
+
+get [watchexec][4] for watching directories.
+
 ```sh
 $ watchexec -e md,html -w locales -w assets ./site.rb
 ```
 
+#### Configuring site.rb
+
+For normal usage you don't need to configure the script at all.
+However, some of the behavior can be changed via environment variables.
+
+- `SITE_ROOT`: change the output path of the script. This does not change the URL in the generated HTML files.
+- `SITE_DOMAIN`: change the domain used in `sitemap.txt`. You won't need this.
+- `SITE_LOCALE`: change the default locale of the website. You won't need this.
+- `VERBOSE`: enable verbose output. Can be useful to debug which files were generated.
+
+
 
 [1]: https://github.com/lite-xl/lite-xl
-[2]: https://github.com/watchexec/watchexec
+[2]: https://developer.mozilla.org/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server
+[3]: https://www.npmjs.com/package/http-server
+[4]: https://github.com/watchexec/watchexec

--- a/site.rb
+++ b/site.rb
@@ -4,23 +4,93 @@ require 'rouge'
 require 'fileutils'
 
 class RedRouge < Redcarpet::Render::HTML
-  def block_code(code, language) "<pre>" + Rouge.highlight(code, language || "bash", 'html') + "</pre>" end
-  def link(link, title, link_content) "<a title='#{title}' #{link =~ /^(http|\/?assets)/ && "target='_blank'"} href='#{link}'>#{link_content}</a>" end
+  def block_code(code, language)
+    "<pre>" + Rouge.highlight(code, language || "bash", 'html') + "</pre>"
+  end
+
+  def link(link, title, link_content)
+    # make all external and asset links to open in new tab
+    "<a title='#{title}' #{link =~ /^(http|\/?assets)/ && "target='_blank'"} href='#{link}'>#{link_content}</a>"
+  end
 end
+
+def slugify(name)
+  name
+    .downcase
+    .gsub(/[^a-z0-9]+/, "-") # replace non-url friendly characters with dashes
+    .gsub(/\-+/, "-") # remove duplicate dashes
+    .gsub(/^\-|\-$/, "") # remove trailing dashes
+end
+
+
+
+# config options
+root = ENV.fetch("SITE_ROOT", "")
+domain = ENV.fetch("SITE_DOMAIN", "https://lite-xl.com")
+default_locale = ENV.fetch("SITE_LOCALE", "en")
+verbose = ENV.key?("VERBOSE")
+
+
+
+root = root.gsub(/\/\\$/, "") + "/" unless root == ""
+FileUtils.rm_rf(root) unless root == ""
 rc = Redcarpet::Markdown.new(RedRouge.new(with_toc_data: true), { fenced_code_blocks: true, tables: true, footnotes: true })
-sitemap = File.open("sitemap.txt", "w")
-sitemap.puts("https://lite-xl.com");
-Dir.glob("locales/*").map { |x| x.gsub("locales/", "") }.map { |locale| 
-  template = File.read("locales/#{locale}/template.html")
-  FileUtils.rm_rf("#{locale}")
-  Dir.glob("locales/#{locale}/**/*.md").select { |x| File.file?(x) }.map { |path|
-    target = path.gsub(/\.md/,".html").gsub(/^locales\//, "")
-    FileUtils.mkdir_p(File.dirname(target)) if !Dir.exist?(File.dirname(target))
-    contents = rc.render(File.read(path))
-    title = (contents.scan(/<\s*h1.*?>(.*?)<\s*\/h1\s*>/).first || ["Lite XL"]).first
-    title = "Lite XL - #{title}" if title != "Lite XL"
-    id = path.gsub("locales/#{locale}", "").gsub(/\.(\w+)$/, "").downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\-+/, "-").gsub(/^\-|\-$/, "")
-    File.write(target, template.gsub("{{ page }}", contents).gsub("{{ title }}", title).gsub("{{ id }}", id))
-    sitemap.write("https://lite-xl.com/#{target == 'index.html' ? '' : target}\n")
+files = Dir
+  .glob("locales/*")
+  .map { |x| x.gsub("locales/", "") }
+  .map { |locale|
+    template = File.read("locales/#{locale}/template.html")
+    FileUtils.rm_rf(root + locale)
+
+    # process markdown files
+    files = Dir
+      .glob("locales/#{locale}/**/*.md")
+      .select { |x| File.file?(x) }
+      .map { |path|
+        basename = path.gsub("locales/#{locale}", "").gsub(/.\w+$/, "")
+
+        # the slugs produced by target and id is different, as target slugifies each component
+        # while id slugifies everything. For instance, path "/locale/en/magic!I don't know" produces
+        # target = /en/magic-i-don-t-know
+        # id = magic-i-don-t-know
+        target = File.join(Pathname(locale + basename).each_filename.map { |component| slugify(component) }) + ".html"
+
+        FileUtils.mkdir_p(root + File.dirname(target)) unless Dir.exist?(root + File.dirname(target))
+
+        contents = rc.render(File.read(path))
+        title = (contents.scan(/<\s*h1.*?>(.*?)<\s*\/h1\s*>/).first || ["Lite XL"]).first
+        title = "Lite XL - #{title}" unless title == "Lite XL"
+        id = slugify(basename)
+
+        contents = template
+          .gsub("{{ page }}", contents)
+          .gsub("{{ title }}", title)
+          .gsub("{{ id }}", id)
+        File.write(root + target, contents)
+
+        # return target filename for sitemap
+        target
+      }
+
+    # html file passthrough
+    files + Dir
+      .glob("locales/#{locale}/**/*.html")
+      .select { |file| file != "locales/#{locale}/template.html" }
+      .each { |file| FileUtils.copy_file(file, root + file.gsub("locales/", ""), true, true) }
   }
-}
+  .flatten
+  .each { |path| puts("#{path} generated.") if verbose }
+  .map { |path| "#{domain}/#{path == "index.html" ? '' : path}" }
+  .unshift(domain) # prepend the domain
+
+# write sitemap
+File.write("#{root}sitemap.txt", files.join("\n") + "\n")
+
+# link index.html for default locale
+FileUtils.ln_sf("#{root}#{default_locale}/index.html", "#{root}index.html")
+
+# copy other files
+unless root == ""
+  FileUtils.cp_r("assets", "#{root}assets")
+  FileUtils.cp("404.html", "#{root}404.html")
+end

--- a/site.rb
+++ b/site.rb
@@ -76,7 +76,9 @@ files = Dir
     files + Dir
       .glob("locales/#{locale}/**/*.html")
       .select { |file| file != "locales/#{locale}/template.html" }
-      .each { |file| FileUtils.copy_file(file, root + file.gsub("locales/", ""), true, true) }
+      .map { |file| [file, root + file.gsub("locales/", "")] }
+      .each { |(src, dest)| FileUtils.copy_file(src, dest, true, true) }
+      .map { |(_, dest)| dest }
   }
   .flatten
   .each { |path| puts("#{path} generated.") if verbose }


### PR DESCRIPTION
This PR includes documentations and expanding the site.rb so that it's easier to read through.

Other than that, I add some config options (which I swear does not take a lot of LOC to implement).

The PR also fixes a bug where the filenames aren't converted properly, such as `/locales/en/blah-blah!blah!blah/magic words`.

Another change is that the script now allows HTML files (except `template.html` for obvious reasons) to pass through.